### PR TITLE
Professions: Keep debug prof, add playable prof

### DIFF
--- a/professions.json
+++ b/professions.json
@@ -2,9 +2,9 @@
   {
     "type": "profession",
     "id": "blobmaster",
-    "name": "Blob Wrangler",
-    "description": "Your choice in vehicle parts seems to greatly unnerve people. But in the Cataclysm, your ultra-sustainable supplies with a unique taste for 'biofuel' will probably keep you alive... so long as you feed it often enough.",
-    "points": 8,
+    "name": "Blob Master Mad Scientist",
+    "description": "You devoted all your free time to your far-fetched biological theories. People called you a crackpot. But a few weeks before the Cataclysm, something changed, you found life in the sewer water, and everything you hoped for came true. Since then, you've worked day and night exploring the limits of blob technology, forming, re-forming, and breeding blobs with incredible abilities. The Cataclysm has been terrible, yes, but for you it's almost been worth it.",
+    "points": 16,
     "skills": [ { "level": 6, "name": "cooking" } ],
     "items": {
       "both": {
@@ -45,6 +45,32 @@
         ],
         "entries": [ { "item": "bfmag", "ammo-item": "bfeed", "charges": 250 } ]
       },
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "panties" ]
+    }
+  },
+    {
+    "type": "profession",
+    "id": "blobamateur",
+    "name": "Blob Amateur Scientist",
+    "description": "You devoted all your free time to your far-fetched biological theories. People called you a crackpot. But a few days before the Cataclysm, something changed, you found life in the sewer water, and everything you hoped for came true. You've created a cooperative new lifeform that promises incredible abilities. The Cataclysm has been terrible, yes, but this might almost be worth it.",
+    "points": 2,
+    "skills": [ { "level": 5, "name": "cooking" } ],
+    "items": {
+      "both": {
+        "items": [
+          "jeans",
+          "longshirt",
+          "socks",
+          "coat_winter",
+          "boots_winter",
+          "knit_scarf",
+          "pockknife",
+          "water_clean",
+          "matches",
+          "gloople"
+        ]
+		},
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
     }


### PR DESCRIPTION
Players are thinking the "Blob Wrangler" is the intended starting profession.
<img width="1387" height="218" alt="2026-06-18 07_16_14-• Discord _ #mod-discussion _ Cataclysm_ Bright Nights — Mozilla Firefox" src="https://github.com/user-attachments/assets/aa596f54-0fd9-465f-a266-6c0cf82d3b7c" />

This PR keeps the "debug" profession, but changed the point value to 16. If someone wants to set char creation points to "Any" and explore the mod, then go for it. 

But it also adds a 2-point profession that starts with just a gloople. This is a head start (among other things, it gives the much faster blob feed recipe versus the recipe that uses hammering), but still only the first step on the tech tree. Player still needs to acquire mutagen to get ooze, gray, and then queen. For someone who's trying to "do a blob run", then this should be the profession they choose. 