### PR TITLE
Frost lancer can use tanks, and allows reloading item

### DIFF
--- a/blob_overwrite.json
+++ b/blob_overwrite.json
@@ -828,7 +828,7 @@
       "qualities": [ { "id": "blobrep", "level": 1 } ],
       "components": [ [ [ "slime_scrap", 1 ] ] ]
     }},
-    "flags": [ "TURRET", "FOLDABLE" ]
+    "flags": [ "TURRET", "FOLDABLE", "USE_TANKS" ]
   },
   {
     "id": "frostie_ram",
@@ -3083,7 +3083,7 @@
     "durability": 10,
     "clip_size": 100,
     "ammo_effects": [ "WIDE" ],
-    "flags": [ "NEVER_JAMS", "NO_RELOAD", "FIRE_20" ]
+    "flags": [ "NEVER_JAMS", "FIRE_20" ]
   },
   {
     "id": "frostie",


### PR DESCRIPTION
This is to show that you in fact, didn't have the proper flag in the vehicle part entry for frost lancer turret. Also remove the no reload flag on the item version, since I don't think that makes any sense if you are supposed to be able to use it yourself.

Should make sure the other fluid weapons (all of them, right?) are given the proper uses_tanks flag if they are meant to be that way.